### PR TITLE
Add `left_label` and `right_label` arguments to `Differ`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -4,6 +4,7 @@ require "difftastic/version"
 require "tempfile"
 
 module Difftastic
+	autoload :ANSI, "difftastic/ansi"
 	autoload :Differ, "difftastic/differ"
 	autoload :Upstream, "difftastic/upstream"
 

--- a/lib/difftastic/ansi.rb
+++ b/lib/difftastic/ansi.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Difftastic::ANSI
+	RED = "\e[91;1m"
+	GREEN = "\e[92;1m"
+	RESET = "\e[0m"
+
+	def self.green(string = "")
+		"#{GREEN}#{string}"
+	end
+
+	def self.red(string = "")
+		"#{RED}#{string}"
+	end
+
+	def self.reset(string = "")
+		"#{RESET}#{string}"
+	end
+
+	def self.strip_formatting(string)
+		string.to_s.gsub(/\e\[[0-9;]*m/, "")
+	end
+end

--- a/test/labels.test.rb
+++ b/test/labels.test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+test "left and right" do
+	output = Difftastic::Differ.new(color: :always, tab_width: 2, left_label: "Left", right_label: "Right").diff_objects(
+		"123",
+		"456"
+	)
+	assert_equal output, "\n\e[91;1mLeft                          \e[92;1mRight\e[0m\n\e[91;1m1 \e[0m\e[91m\"123\"\e[0m                       \e[92;1m1 \e[0m\e[92m\"456\"\e[0m\n\n"
+end
+
+test "only left" do
+	output = Difftastic::Differ.new(color: :always, tab_width: 2, left_label: "Left").diff_objects(
+		"123",
+		"456"
+	)
+	assert_equal output, "\n\e[91;1mLeft                          \e[0m\n\e[91;1m1 \e[0m\e[91m\"123\"\e[0m                       \e[92;1m1 \e[0m\e[92m\"456\"\e[0m\n\n"
+end
+
+test "only right" do
+	output = Difftastic::Differ.new(color: :always, tab_width: 2, right_label: "Right").diff_objects(
+		"123",
+		"456"
+	)
+	assert_equal output, "\n                              \e[92;1mRight\e[0m\n\e[91;1m1 \e[0m\e[91m\"123\"\e[0m                       \e[92;1m1 \e[0m\e[92m\"456\"\e[0m\n\n"
+end
+
+test "super wide diff" do
+	output = Difftastic::Differ.new(color: :always, tab_width: 2, left_label: "Left", right_label: "Right").diff_objects(
+		"this is a super long diff to demonstrate that the labels get positioned incorrectly",
+		"this is a super long diff to demonstrate that the labels get positioned correctly",
+	)
+	assert_equal output, "\n\e[91;1mLeft                                                         \e[92;1mRight\e[0m\n\e[91;1m1 \e[0m\e[91m\"\e[0m\e[91mthis\e[0m\e[91m \e[0m\e[91mis\e[0m\e[91m \e[0m\e[91ma\e[0m\e[91m \e[0m\e[91msuper\e[0m\e[91m \e[0m\e[91mlong\e[0m\e[91m \e[0m\e[91mdiff\e[0m\e[91m \e[0m\e[91mto\e[0m\e[91m \e[0m\e[91mdemonstrate\e[0m\e[91m \e[0m\e[91mthat\e[0m\e[91m \e[0m\e[91mthe\e[0m\e[91m \e[0m\e[91mlabels\e[0m\e[91m \e[0m \e[92;1m1 \e[0m\e[92m\"\e[0m\e[92mthis\e[0m\e[92m \e[0m\e[92mis\e[0m\e[92m \e[0m\e[92ma\e[0m\e[92m \e[0m\e[92msuper\e[0m\e[92m \e[0m\e[92mlong\e[0m\e[92m \e[0m\e[92mdiff\e[0m\e[92m \e[0m\e[92mto\e[0m\e[92m \e[0m\e[92mdemonstrate\e[0m\e[92m \e[0m\e[92mthat\e[0m\e[92m \e[0m\e[92mthe\e[0m\e[92m \e[0m\e[92mlabels\e[0m\e[92m \e[0m\n\e[91;1m\e[2m. \e[0m\e[0m\e[91mget\e[0m\e[91m \e[0m\e[91mpositioned\e[0m\e[91m \e[0m\e[91;1;4mincorrectly\e[0m\e[91m\"\e[0m                                \e[92;1m\e[2m. \e[0m\e[0m\e[92mget\e[0m\e[92m \e[0m\e[92mpositioned\e[0m\e[92m \e[0m\e[92;1;4mcorrectly\e[0m\e[92m\"\e[0m\n\n"
+end


### PR DESCRIPTION
This pull request introduces label support for diffs. By introducing `left_label` and `right_label` arguments to the `Difftastic::Differ` class so we can render labels above the code blocks on each side.

![CleanShot 2025-01-22 at 16 37 04@2x](https://github.com/user-attachments/assets/6691c604-e2de-4ac1-842b-7fb81e3ab898)
