### PR TITLE
Use `**` to find the `difft` executable

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -40,7 +40,7 @@ module Difftastic
 				MESSAGE
 			end
 
-			exe_file = Dir.glob(File.expand_path(File.join(exe_path, "*", "difft"))).find do |f|
+			exe_file = Dir.glob(File.expand_path(File.join(exe_path, "**", "difft"))).find do |f|
 				Gem::Platform.match_gem?(Gem::Platform.new(File.basename(File.dirname(f))), GEM_NAME)
 			end
 		end


### PR DESCRIPTION
It seems that a single `*` does not expand out to find the executable in the `exe_path`. See the following:

```
$ ls /Users/tcannon/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/difftastic-0.0.1/exe/*/difft
zsh: no matches found: /Users/tcannon/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/difftastic-0.0.1/exe/*/difft

$ ls /Users/tcannon/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/difftastic-0.0.1/exe/difft
-rwxr-xr-x  1 tcannon  staff   170B Jan 22 11:08 /Users/tcannon/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/difftastic-0.0.1/exe/difft

$ ls /Users/tcannon/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/difftastic-0.0.1/exe/**/difft
-rwxr-xr-x  1 tcannon  staff   170B Jan 22 11:08 /Users/tcannon/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/difftastic-0.0.1/exe/difft
```

This fixes #2 