### PR TITLE
Improve pretty output of empty `Set`s

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -107,6 +107,8 @@ module Difftastic
 				"[#{items.join(', ')}]"
 			end
 		when Set
+			return %(Set: {}) if object.empty?
+
 			new_lines = false
 			length = 0
 			items = object.to_a.sort!.map do |item|
@@ -117,9 +119,9 @@ module Difftastic
 			end
 
 			if new_lines || length > max_width - (indent * tab_width)
-				"Set[\n#{"\t" * (indent + 1)}#{items.join(",\n#{"\t" * (indent + 1)}")},\n#{"\t" * indent}]"
+				"Set: {\n#{"\t" * (indent + 1)}#{items.join(",\n#{"\t" * (indent + 1)}")},\n#{"\t" * indent}}"
 			else
-				"Set[#{items.join(', ')}]"
+				"Set: {#{items.join(', ')}}"
 			end
 		when Module
 			object.name

--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -107,7 +107,7 @@ module Difftastic
 				"[#{items.join(', ')}]"
 			end
 		when Set
-			return %(Set: {}) if object.empty?
+			return %(Set[]) if object.empty?
 
 			new_lines = false
 			length = 0
@@ -119,9 +119,9 @@ module Difftastic
 			end
 
 			if new_lines || length > max_width - (indent * tab_width)
-				"Set: {\n#{"\t" * (indent + 1)}#{items.join(",\n#{"\t" * (indent + 1)}")},\n#{"\t" * indent}}"
+				"Set[\n#{"\t" * (indent + 1)}#{items.join(",\n#{"\t" * (indent + 1)}")},\n#{"\t" * indent}]"
 			else
-				"Set: {#{items.join(', ')}}"
+				"Set[#{items.join(', ')}]"
 			end
 		when Module
 			object.name

--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Difftastic::Differ
-	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil)
+	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil, display: "side-by-side-show-both")
 		@show_paths = false
 		@background = background => :dark | :light | nil
 		@color = color => :always | :never | :auto | nil
@@ -12,6 +12,7 @@ class Difftastic::Differ
 		@underline_highlights = underline_highlights => true | false
 		@left_label = left_label => String | nil
 		@right_label = right_label => String | nil
+		@display = display
 	end
 
 	def diff_objects(old, new)
@@ -292,6 +293,7 @@ class Difftastic::Differ
 			("--background=#{@background}" if @background),
 			("--syntax-highlight=#{@syntax_highlight}" if @syntax_highlight),
 			("--tab-width=#{@tab_width}" if @tab_width),
+			("--display=#{@display}" if @display),
 		].compact!
 
 		result = Difftastic.execute(options.join(" "))

--- a/test/difftastic.test.rb
+++ b/test/difftastic.test.rb
@@ -9,6 +9,15 @@ test do
 	assert_equal output, "\e[91;1m1 \e[0m[\e[91m1\e[0m, 2, \e[91m3\e[0m]                   \e[92;1m1 \e[0m[\e[92m3\e[0m, 2, \e[92m1\e[0m]\n\n"
 end
 
+test "set" do
+	a = "<html>\n\t<body>\n\t\t<h1>Hello, world!</h1>\n\t</body>\n</html>"
+	b = "<html>\n\t<body>\n\t\t<h1>Goodbye, world!</h1>\n\t</body>\n</html>"
+
+	output = Difftastic::Differ.new.diff_objects(Set.new, Set.new([1]))
+
+	assert_equal output, "1 Set: {}                     1 Set: {1}\n\n"
+end
+
 test "html" do
 	a = "<html>\n\t<body>\n\t\t<h1>Hello, world!</h1>\n\t</body>\n</html>"
 	b = "<html>\n\t<body>\n\t\t<h1>Goodbye, world!</h1>\n\t</body>\n</html>"

--- a/test/difftastic.test.rb
+++ b/test/difftastic.test.rb
@@ -10,9 +10,6 @@ test do
 end
 
 test "set" do
-	a = "<html>\n\t<body>\n\t\t<h1>Hello, world!</h1>\n\t</body>\n</html>"
-	b = "<html>\n\t<body>\n\t\t<h1>Goodbye, world!</h1>\n\t</body>\n</html>"
-
 	output = Difftastic::Differ.new.diff_objects(Set.new, Set.new([1]))
 
 	assert_equal output, "1 Set[]                       1 Set[1]\n\n"

--- a/test/difftastic.test.rb
+++ b/test/difftastic.test.rb
@@ -15,7 +15,7 @@ test "set" do
 
 	output = Difftastic::Differ.new.diff_objects(Set.new, Set.new([1]))
 
-	assert_equal output, "1 Set: {}                     1 Set: {1}\n\n"
+	assert_equal output, "1 Set[]                       1 Set[1]\n\n"
 end
 
 test "html" do

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -19,7 +19,7 @@ test "sets are sorted" do
 	object = Set[2, 3, 1]
 
 	assert_equal_ruby Difftastic.pretty(object), <<~RUBY.chomp
-		Set: {1, 2, 3}
+		Set[1, 2, 3]
 	RUBY
 end
 
@@ -132,7 +132,7 @@ test "long arrays" do
 		a: [1, 2, 3],
 		b: {
 			"c" => 1.3232332,
-			[1, 2, 3] => Set: {1, 2, 3, 4},
+			[1, 2, 3] => Set[1, 2, 3, 4],
 		},
 	},
 	[

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -19,7 +19,7 @@ test "sets are sorted" do
 	object = Set[2, 3, 1]
 
 	assert_equal_ruby Difftastic.pretty(object), <<~RUBY.chomp
-		Set[1, 2, 3]
+		Set: {1, 2, 3}
 	RUBY
 end
 
@@ -132,7 +132,7 @@ test "long arrays" do
 		a: [1, 2, 3],
 		b: {
 			"c" => 1.3232332,
-			[1, 2, 3] => Set[1, 2, 3, 4],
+			[1, 2, 3] => Set: {1, 2, 3, 4},
 		},
 	},
 	[


### PR DESCRIPTION
Comparing an empty `Set` with a `Set` with items is kinda confusing right now:

![CleanShot 2025-01-28 at 01 46 38@2x](https://github.com/user-attachments/assets/38339dee-3da3-4a85-abdd-0bd9d5106168)

Sadly we cannot just return `Set[]` for an empty set, since `difftastic`  just strips the `Set` away and represents it as `{}`, which is even more confusing because it looks like an empty `Hash`.

![CleanShot 2025-01-28 at 01 50 50@2x](https://github.com/user-attachments/assets/91bee64d-b37f-42d0-b606-ed9831ccba5e)

Which is why I'm proposing to change the pretty output of `Set` instances 
from: `Set[1, 2, 3]`
to:     `Set: {1, 2, 3}`

This also matches the default inspect more closely:

```
irb(main):001> Set.new([1,2,3])
=> #<Set: {1, 2, 3}>
```

With that you get a less confusing output in my opinion:

![CleanShot 2025-01-28 at 01 55 07@2x](https://github.com/user-attachments/assets/a0f23c0e-7d55-49cb-92c7-317f688182ff)


