### PR TITLE
Don't crash when `Differ` receives labels without a `tab_width`

### DIFF
--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Difftastic::Differ
+	DEFAULT_TAB_WIDTH = 2
+
 	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil)
 		@show_paths = false
 		@background = background => :dark | :light | nil
@@ -15,7 +17,7 @@ class Difftastic::Differ
 	end
 
 	def diff_objects(old, new)
-		tab_width = @tab_width || 2
+		tab_width = @tab_width || DEFAULT_TAB_WIDTH
 
 		old = Difftastic.pretty(old, tab_width:)
 		new = Difftastic.pretty(new, tab_width:)
@@ -343,10 +345,11 @@ class Difftastic::Differ
 	private
 
 	def right_label_offset(line)
+		tab_width = @tab_width || DEFAULT_TAB_WIDTH
 		stripped_line = ::Difftastic::ANSI.strip_formatting(line)
-		_lhs, rhs = stripped_line.split(/\s{#{@tab_width},}/, 2)
+		_lhs, rhs = stripped_line.split(/\s{#{tab_width},}/, 2)
 
-		offset = (stripped_line.index("#{' ' * @tab_width}#{rhs}") || 0) + @tab_width
+		offset = (stripped_line.index("#{' ' * tab_width}#{rhs}") || 0) + tab_width
 		minimum_offset = 29
 
 		[minimum_offset, offset].max

--- a/test/labels.test.rb
+++ b/test/labels.test.rb
@@ -32,3 +32,12 @@ test "super wide diff" do
 
 	assert_equal output, "\n\e[91;1mLeft                                                                                      \e[92;1mRight\e[0m\n\e[91;1m1 \e[0m\e[91m\"\e[0m\e[91mthis\e[0m\e[91m \e[0m\e[91mis\e[0m\e[91m \e[0m\e[91ma\e[0m\e[91m \e[0m\e[91msuper\e[0m\e[91m \e[0m\e[91mlong\e[0m\e[91m \e[0m\e[91mdiff\e[0m\e[91m \e[0m\e[91mto\e[0m\e[91m \e[0m\e[91mdemonstrate\e[0m\e[91m \e[0m\e[91mthat\e[0m\e[91m \e[0m\e[91mthe\e[0m\e[91m \e[0m\e[91mlabels\e[0m\e[91m \e[0m\e[91mget\e[0m\e[91m \e[0m\e[91mpositioned\e[0m\e[91m \e[0m\e[91;1;4mincorrectly\e[0m\e[91m\"\e[0m   \e[92;1m1 \e[0m\e[92m\"\e[0m\e[92mthis\e[0m\e[92m \e[0m\e[92mis\e[0m\e[92m \e[0m\e[92ma\e[0m\e[92m \e[0m\e[92msuper\e[0m\e[92m \e[0m\e[92mlong\e[0m\e[92m \e[0m\e[92mdiff\e[0m\e[92m \e[0m\e[92mto\e[0m\e[92m \e[0m\e[92mdemonstrate\e[0m\e[92m \e[0m\e[92mthat\e[0m\e[92m \e[0m\e[92mthe\e[0m\e[92m \e[0m\e[92mlabels\e[0m\e[92m \e[0m\e[92mget\e[0m\e[92m \e[0m\e[92mpositioned\e[0m\e[92m \e[0m\e[92;1;4mcorrectly\e[0m\e[92m\"\e[0m\n\n"
 end
+
+test "with no tab_width" do
+	output = Difftastic::Differ.new(color: :always, left_label: "Left", right_label: "Right").diff_objects(
+		"Left",
+		"Right"
+	)
+
+	assert_equal output, "\n\e[91;1mLeft                          \e[92;1mRight\e[0m\n\e[91;1m1 \e[0m\e[91m\"Left\"\e[0m                      \e[92;1m1 \e[0m\e[92m\"Right\"\e[0m\n\n"
+end


### PR DESCRIPTION
If you called `diff_objects` on a `Difftastic::Differ` instance that received `left_label`/`right_label` but no `tab_width`:

```ruby
differ = Difftastic::Differ.new(color: :always, left_label: "Left", right_label: "Right")

differ.diff_objects("Left", "Right")
```

 it would crash with:

```
    unexpected TypeError
      no implicit conversion from nil to integer
        /Users/marcoroth/Development/difftastic-ruby/lib/difftastic/differ.rb:350:in 'String#*'
          /Users/marcoroth/Development/difftastic-ruby/lib/difftastic/differ.rb:350:in 'Difftastic::Differ#right_label_offset'
            /Users/marcoroth/Development/difftastic-ruby/lib/difftastic/differ.rb:310:in 'Difftastic::Differ#diff_files'
              /Users/marcoroth/Development/difftastic-ruby/lib/difftastic/differ.rb:280:in 'Difftastic::Differ#diff_strings'
                /Users/marcoroth/Development/difftastic-ruby/lib/difftastic/differ.rb:23:in 'Difftastic::Differ#diff_objects'
```

This pull request adds a fallback value for the `tab_width` in the `Differ#right_label_offset` method so it doesn't crash without passing a `tab_width` argument.