### PR TITLE
Add `display` option as an argument to `Difftastic::Differ`

### DIFF
--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -3,7 +3,7 @@
 class Difftastic::Differ
 	DEFAULT_TAB_WIDTH = 2
 
-	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil)
+	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil, display: "side-by-side-show-both")
 		@show_paths = false
 		@background = background => :dark | :light | nil
 		@color = color => :always | :never | :auto | nil
@@ -14,6 +14,7 @@ class Difftastic::Differ
 		@underline_highlights = underline_highlights => true | false
 		@left_label = left_label => String | nil
 		@right_label = right_label => String | nil
+		@display = display
 	end
 
 	def diff_objects(old, new)
@@ -294,6 +295,7 @@ class Difftastic::Differ
 			("--background=#{@background}" if @background),
 			("--syntax-highlight=#{@syntax_highlight}" if @syntax_highlight),
 			("--tab-width=#{@tab_width}" if @tab_width),
+			("--display=#{@display}" if @display),
 		].compact!
 
 		result = Difftastic.execute(options.join(" "))

--- a/test/display.test.rb
+++ b/test/display.test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+test "default" do
+	output = Difftastic::Differ.new(color: :never).diff_objects([], [1, 2, 3])
+
+	assert_equal output, "1 []                          1 [1, 2, 3]\n\n"
+end
+
+test "side-by-side-show-both" do
+	output = Difftastic::Differ.new(color: :never, display: "side-by-side-show-both").diff_objects([], [1, 2, 3])
+
+	assert_equal output, "1 []                          1 [1, 2, 3]\n\n"
+end
+
+test "side-by-side" do
+	output = Difftastic::Differ.new(color: :never, display: "side-by-side").diff_objects([], [1, 2, 3])
+
+	assert_equal output, "1 [1, 2, 3]\n\n"
+end
+
+test "inline" do
+	output = Difftastic::Differ.new(color: :never, display: "inline").diff_objects([], [1, 2, 3])
+
+	assert_equal output, "1    []\n   1 [1, 2, 3]\n\n"
+end

--- a/test/display.test.rb
+++ b/test/display.test.rb
@@ -18,6 +18,12 @@ test "side-by-side" do
 	assert_equal output, "1 [1, 2, 3]\n\n"
 end
 
+test "side-by-side with left side change" do
+	output = Difftastic::Differ.new(color: :never, display: "side-by-side").diff_objects([3, 2, 1], [1, 2, 3])
+
+	assert_equal output, "1 [3, 2, 1]                   1 [1, 2, 3]\n\n"
+end
+
 test "inline" do
 	output = Difftastic::Differ.new(color: :never, display: "inline").diff_objects([], [1, 2, 3])
 


### PR DESCRIPTION
This pull request adds the `display` option to `Difftastic::Differ`. It now defaults to `"side-by-side-show-both"`. 

The implicit default was `side-by-side` which is confusing in some cases (see #5):


TLDR: if there was no change to the left file `difftastic` would hide the left file, resulting in something like:

<img src="https://github.com/user-attachments/assets/0b23a8db-508d-4a48-946b-cdab77be40bd" width="50%">


Which is why this pull request introduces the `display`  option and defaults the mode to`"side-by-side-show-both"`

Here are the docs for the `display` option.
```
--display <MODE>
    Display mode for showing results.

    side-by-side: Display the before file and the after file in two separate columns, with line numbers aligned
    according to unchanged content. If a change is exclusively additions or exclusively removals, use a single
    column.

    side-by-side-show-both: The same as side-by-side, but always uses two columns.

    inline: A single column display, closer to traditional diff display.

    json: Output the results as a machine-readable JSON array with an element per file.

    [env: DFT_DISPLAY=]
    [default: side-by-side]
    [possible values: side-by-side, side-by-side-show-both, inline, json]
```

I intentionally left out the `json` mode for now since it's experimental:

```
JSON output is an unstable feature and its format may change in future. To enable JSON output, set the environment variable DFT_UNSTABLE=yes.
```