### PR TITLE
Add tests for empty objects and improve empty style of `Hash`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -74,6 +74,8 @@ module Difftastic
 	def self.pretty(object, indent: 0, tab_width: 2, max_width: 60)
 		case object
 		when Hash
+			return "{}" if object.empty?
+
 			buffer = +"{\n"
 			indent += 1
 			object.each do |key, value|

--- a/test/difftastic.test.rb
+++ b/test/difftastic.test.rb
@@ -15,7 +15,7 @@ test "empty set" do
 		Set.new([1, 2, 3])
 	)
 
-	assert_equal output, "1 Set[]                       1 Set[1, 2, 3]\n\n"
+	assert_equal output, %(1 Set[]                       1 Set[1, 2, 3]\n\n)
 end
 
 test "empty array" do
@@ -33,7 +33,7 @@ test "empty string" do
 		"String"
 	)
 
-	assert_equal output, "1 \"\"                          1 \"String\"\n\n"
+	assert_equal output, %(1 ""                          1 "String"\n\n)
 end
 
 test "empty symbol" do
@@ -42,7 +42,7 @@ test "empty symbol" do
 		:Symbol
 	)
 
-	assert_equal output, "1 :\"\"                         1 :Symbol\n\n"
+	assert_equal output, %(1 :""                         1 :Symbol\n\n)
 end
 
 test "html" do

--- a/test/difftastic.test.rb
+++ b/test/difftastic.test.rb
@@ -9,6 +9,42 @@ test do
 	assert_equal output, "\e[91;1m1 \e[0m[\e[91m1\e[0m, 2, \e[91m3\e[0m]                   \e[92;1m1 \e[0m[\e[92m3\e[0m, 2, \e[92m1\e[0m]\n\n"
 end
 
+test "empty set" do
+	output = Difftastic::Differ.new.diff_objects(
+		Set.new,
+		Set.new([1, 2, 3])
+	)
+
+	assert_equal output, "1 Set[]                       1 Set[1, 2, 3]\n\n"
+end
+
+test "empty array" do
+	output = Difftastic::Differ.new(color: :never, tab_width: 2).diff_objects(
+		[],
+		[3, 2, 1]
+	)
+
+	assert_equal output, "1 []                          1 [3, 2, 1]\n\n"
+end
+
+test "empty string" do
+	output = Difftastic::Differ.new(color: :never, tab_width: 2).diff_objects(
+		"",
+		"String"
+	)
+
+	assert_equal output, "1 \"\"                          1 \"String\"\n\n"
+end
+
+test "empty symbol" do
+	output = Difftastic::Differ.new(color: :never, tab_width: 2).diff_objects(
+		:"",
+		:Symbol
+	)
+
+	assert_equal output, "1 :\"\"                         1 :Symbol\n\n"
+end
+
 test "html" do
 	a = "<html>\n\t<body>\n\t\t<h1>Hello, world!</h1>\n\t</body>\n</html>"
 	b = "<html>\n\t<body>\n\t\t<h1>Goodbye, world!</h1>\n\t</body>\n</html>"

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -15,6 +15,26 @@ test "object with no properties" do
 	RUBY
 end
 
+test "empty set" do
+	assert_equal_ruby Difftastic.pretty(Set.new), "Set[]"
+end
+
+test "empty array" do
+	assert_equal_ruby Difftastic.pretty([]), "[]"
+end
+
+test "empty object" do
+	assert_equal_ruby Difftastic.pretty({}), "{}"
+end
+
+test "empty string" do
+	assert_equal_ruby Difftastic.pretty(""), %("")
+end
+
+test "empty symbol" do
+	assert_equal_ruby Difftastic.pretty(:""), %(:"")
+end
+
 test "sets are sorted" do
 	object = Set[2, 3, 1]
 


### PR DESCRIPTION
Looks like the empty sets are fine after the changes in #7, so we don't need #5 - which is good!

Though I thought it makes sense to add some tests to explicitly test the empty version of all objects.

This pull request also slightly tweaks the empty style of `Hash` from:
```ruby
{
}
```
to

```ruby
{}
```