### PR TITLE
Define `ExecutableNotFoundException`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -11,6 +11,9 @@ module Difftastic
 	GEM_NAME = "difftastic"
 	DEFAULT_DIR = File.expand_path(File.join(__dir__, "..", "exe"))
 
+	class ExecutableNotFoundException < StandardError
+	end
+
 	def self.execute(command)
 		`#{executable} #{command}`
 	end


### PR DESCRIPTION
I just noticed in a test suite that when the difftastic executable couldn't be found that it tries to throw a `ExecutableNotFoundException` with instructions on how to install `difftastic`. 

But I noticed that the error said `NameError: uninitialized constant Difftastic::ExecutableNotFoundException`:


```
unexpected NameError
uninitialized constant Difftastic::ExecutableNotFoundException
/Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:52:in 'Difftastic.executable'
/Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:18:in 'Difftastic.execute'
```

After a quick search in the codebase I found out that the gem doesn't define that error class. This pull request adds a definition for the `Difftastic::ExecutableNotFoundException`. 
