### PR TITLE
Add `width` argument to `Difftastic::Differ`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can configure the `Difftastic::Differ` instance with various options:
 - `color`: Set the color mode (`:always`, `:never`, or `:auto`).
 - `syntax_highlight`: Enable or disable syntax highlighting (`:on` or `:off`).
 - `context`: Set the number of context lines to display.
+- `width`: Use this many columns when calculating line wrapping. If not specified, difftastic will detect the terminal width.
 - `tab_width`: Set the tab width for indentation.
 - `parse_error_limit`: Set the limit for parse errors.
 - `underline_highlights`: Enable or disable underlining highlights (`true` or `false`).

--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -353,7 +353,11 @@ class Difftastic::Differ
 		stripped_line = ::Difftastic::ANSI.strip_formatting(line)
 		_lhs, rhs = stripped_line.split(/\s{#{tab_width},}/, 2)
 
-		offset = (stripped_line.index("#{' ' * tab_width}#{rhs}") || 0) + tab_width
+		index = stripped_line.index("#{' ' * tab_width}#{rhs}")
+		index = @width / 2 if @width && index.nil?
+		index = 0 if index.nil?
+
+		offset = index + tab_width
 		minimum_offset = 29
 
 		[minimum_offset, offset].max

--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -3,12 +3,13 @@
 class Difftastic::Differ
 	DEFAULT_TAB_WIDTH = 2
 
-	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil, display: "side-by-side-show-both")
+	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, width: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil, display: "side-by-side-show-both")
 		@show_paths = false
 		@background = background => :dark | :light | nil
 		@color = color => :always | :never | :auto | nil
 		@syntax_highlight = syntax_highlight => :on | :off | nil
 		@context = context => Integer | nil
+		@width = width => Integer | nil
 		@tab_width = tab_width => Integer | nil
 		@parse_error_limit = parse_error_limit => Integer | nil
 		@underline_highlights = underline_highlights => true | false
@@ -296,6 +297,7 @@ class Difftastic::Differ
 			("--syntax-highlight=#{@syntax_highlight}" if @syntax_highlight),
 			("--tab-width=#{@tab_width}" if @tab_width),
 			("--display=#{@display}" if @display),
+			("--width=#{@width}" if @width),
 		].compact!
 
 		result = Difftastic.execute(options.join(" "))

--- a/test/labels.test.rb
+++ b/test/labels.test.rb
@@ -24,13 +24,49 @@ test "only right" do
 	assert_equal output, "\n                              \e[92;1mRight\e[0m\n\e[91;1m1 \e[0m\e[91m\"123\"\e[0m                       \e[92;1m1 \e[0m\e[92m\"456\"\e[0m\n\n"
 end
 
-test "super wide diff" do
-	output = Difftastic::Differ.new(color: :always, tab_width: 2, left_label: "Left", right_label: "Right").diff_objects(
+test "long line diff with color" do
+	output = Difftastic::Differ.new(color: :always, tab_width: 2, left_label: "Left", right_label: "Right", width: 80).diff_objects(
 		"this is a super long diff to demonstrate that the labels get positioned incorrectly",
 		"this is a super long diff to demonstrate that the labels get positioned correctly",
 	)
 
-	assert_equal output, "\n\e[91;1mLeft                                                         \e[92;1mRight\e[0m\n\e[91;1m1 \e[0m\e[91m\"\e[0m\e[91mthis\e[0m\e[91m \e[0m\e[91mis\e[0m\e[91m \e[0m\e[91ma\e[0m\e[91m \e[0m\e[91msuper\e[0m\e[91m \e[0m\e[91mlong\e[0m\e[91m \e[0m\e[91mdiff\e[0m\e[91m \e[0m\e[91mto\e[0m\e[91m \e[0m\e[91mdemonstrate\e[0m\e[91m \e[0m\e[91mthat\e[0m\e[91m \e[0m\e[91mthe\e[0m\e[91m \e[0m\e[91mlabels\e[0m\e[91m \e[0m \e[92;1m1 \e[0m\e[92m\"\e[0m\e[92mthis\e[0m\e[92m \e[0m\e[92mis\e[0m\e[92m \e[0m\e[92ma\e[0m\e[92m \e[0m\e[92msuper\e[0m\e[92m \e[0m\e[92mlong\e[0m\e[92m \e[0m\e[92mdiff\e[0m\e[92m \e[0m\e[92mto\e[0m\e[92m \e[0m\e[92mdemonstrate\e[0m\e[92m \e[0m\e[92mthat\e[0m\e[92m \e[0m\e[92mthe\e[0m\e[92m \e[0m\e[92mlabels\e[0m\e[92m \e[0m\n\e[91;1m\e[2m. \e[0m\e[0m\e[91mget\e[0m\e[91m \e[0m\e[91mpositioned\e[0m\e[91m \e[0m\e[91;1;4mincorrectly\e[0m\e[91m\"\e[0m                                \e[92;1m\e[2m. \e[0m\e[0m\e[92mget\e[0m\e[92m \e[0m\e[92mpositioned\e[0m\e[92m \e[0m\e[92;1;4mcorrectly\e[0m\e[92m\"\e[0m\n\n"
+	assert_equal output, "\n\e[91;1mLeft                                      \e[92;1mRight\e[0m\n\e[91;1m1 \e[0m\e[91m\"\e[0m\e[91mthis\e[0m\e[91m \e[0m\e[91mis\e[0m\e[91m \e[0m\e[91ma\e[0m\e[91m \e[0m\e[91msuper\e[0m\e[91m \e[0m\e[91mlong\e[0m\e[91m \e[0m\e[91mdiff\e[0m\e[91m \e[0m\e[91mto\e[0m\e[91m \e[0m\e[91mdemonst\e[0m \e[92;1m1 \e[0m\e[92m\"\e[0m\e[92mthis\e[0m\e[92m \e[0m\e[92mis\e[0m\e[92m \e[0m\e[92ma\e[0m\e[92m \e[0m\e[92msuper\e[0m\e[92m \e[0m\e[92mlong\e[0m\e[92m \e[0m\e[92mdiff\e[0m\e[92m \e[0m\e[92mto\e[0m\e[92m \e[0m\e[92mdemonst\e[0m\n\e[91;1m\e[2m. \e[0m\e[0m\e[91mrate\e[0m\e[91m \e[0m\e[91mthat\e[0m\e[91m \e[0m\e[91mthe\e[0m\e[91m \e[0m\e[91mlabels\e[0m\e[91m \e[0m\e[91mget\e[0m\e[91m \e[0m\e[91mpositioned\e[0m\e[91m \e[0m\e[91;1;4mi\e[0m \e[92;1m\e[2m. \e[0m\e[0m\e[92mrate\e[0m\e[92m \e[0m\e[92mthat\e[0m\e[92m \e[0m\e[92mthe\e[0m\e[92m \e[0m\e[92mlabels\e[0m\e[92m \e[0m\e[92mget\e[0m\e[92m \e[0m\e[92mpositioned\e[0m\e[92m \e[0m\e[92;1;4mc\e[0m\n\e[91;1m\e[2m. \e[0m\e[0m\e[91;1;4mncorrectly\e[0m\e[91m\"\e[0m                           \e[92;1m\e[2m. \e[0m\e[0m\e[92;1;4morrectly\e[0m\e[92m\"\e[0m\n\n"
+end
+
+test "long line diff width=80" do
+	output = Difftastic::Differ.new(color: :never, tab_width: 2, left_label: "Left", right_label: "Right", width: 80).diff_objects(
+		"this is a super long diff to demonstrate that the labels get positioned incorrectly",
+		"this is a super long diff to demonstrate that the labels get positioned correctly",
+	)
+
+	assert_equal output, "\n\e[91;1mLeft                                      \e[92;1mRight\e[0m\n1 \"this is a super long diff to demonst 1 \"this is a super long diff to demonst\n. rate that the labels get positioned i . rate that the labels get positioned c\n. ncorrectly\"                           . orrectly\"\n\n"
+end
+
+test "long line diff width=120" do
+	output = Difftastic::Differ.new(color: :never, tab_width: 2, left_label: "Left", right_label: "Right", width: 120).diff_objects(
+		"this is a super long diff to demonstrate that the labels get positioned incorrectly",
+		"this is a super long diff to demonstrate that the labels get positioned correctly",
+	)
+
+	assert_equal output, "\n\e[91;1mLeft                                                          \e[92;1mRight\e[0m\n1 \"this is a super long diff to demonstrate that the labels 1 \"this is a super long diff to demonstrate that the labels\n.  get positioned incorrectly\"                              .  get positioned correctly\"\n\n"
+end
+
+test "long line diff width=150" do
+	output = Difftastic::Differ.new(color: :never, tab_width: 2, left_label: "Left", right_label: "Right", width: 150).diff_objects(
+		"this is a super long diff to demonstrate that the labels get positioned incorrectly",
+		"this is a super long diff to demonstrate that the labels get positioned correctly",
+	)
+
+	assert_equal output, "\n\e[91;1mLeft                                                                         \e[92;1mRight\e[0m\n1 \"this is a super long diff to demonstrate that the labels get positioned 1 \"this is a super long diff to demonstrate that the labels get positioned\n.  incorrectly\"                                                            .  correctly\"\n\n"
+end
+
+test "long line diff width=180" do
+	output = Difftastic::Differ.new(color: :never, tab_width: 2, left_label: "Left", right_label: "Right", width: 180).diff_objects(
+		"this is a super long diff to demonstrate that the labels get positioned incorrectly",
+		"this is a super long diff to demonstrate that the labels get positioned correctly",
+	)
+
+	assert_equal output, "\n\e[91;1mLeft                                                                                      \e[92;1mRight\e[0m\n1 \"this is a super long diff to demonstrate that the labels get positioned incorrectly\"   1 \"this is a super long diff to demonstrate that the labels get positioned correctly\"\n\n"
 end
 
 test "with no tab_width" do

--- a/test/width.test.rb
+++ b/test/width.test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+test "width=20" do
+	output = Difftastic::Differ.new(color: :never, width: 20).diff_strings("123 456", "123 456 789")
+
+	assert_equal output, "1 123 456 1 123 456\n.         .  789\n\n"
+end
+
+test "width=27" do
+	output = Difftastic::Differ.new(color: :never, width: 27).diff_strings("123 456", "123 456 789")
+
+	assert_equal output, "1 123 456     1 123 456 789\n\n"
+end
+
+test "no width" do
+	output = Difftastic::Differ.new(color: :never).diff_strings("123 456", "123 456 789")
+
+	assert_equal output, "1 123 456                     1 123 456 789\n\n"
+end


### PR DESCRIPTION
This pull request adds a `width` argument to the `Difftastic::Differ` class. By default it will detect the terminal width. But if specific it will line-wrap the two columns based on the provided `width`.

I noticed that the `super wide diff` labels test was flaky locally - depending on the terminal size/width. This pull request now also updates that test by setting a fixed `width` value for that test, so it's not terminal width dependent.

Additionally, if we have the `@width` available, we can calculate the `right_label_offset` based off of it. Making the label position more reliable in these edge-cases:

**Before:**
![CleanShot 2025-01-28 at 18 27 05@2x](https://github.com/user-attachments/assets/9d831434-27a9-4538-9154-f7e286ca24a8)

**After:**
![CleanShot 2025-01-28 at 18 26 51@2x](https://github.com/user-attachments/assets/f66d542e-93d1-416b-a26f-20507b7a2975)

```
--width <COLUMNS>
    Use this many columns when calculating line wrapping. If not specified, difftastic will detect the terminal width.[env: DFT_WIDTH=]
```
