### PR TITLE
Add a `max_depth` and `max_instance_variables` argument to `pretty`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -71,7 +71,7 @@ module Difftastic
 		exe_file
 	end
 
-	def self.pretty(object, indent: 0, tab_width: 2, max_width: 60)
+	def self.pretty(object, indent: 0, tab_width: 2, max_width: 60, max_depth: 5, max_instance_variables: 10)
 		case object
 		when Hash
 			return "{}" if object.empty?
@@ -130,18 +130,43 @@ module Difftastic
 		else
 			buffer = +""
 			instance_variables = object.instance_variables
-			if instance_variables.length > 0
+			if instance_variables.length > 0 && indent < max_depth
 				buffer << "#{object.class.name}(\n"
 				indent += 1
-				object.instance_variables.each do |name|
-					buffer << ("\t" * indent)
-					buffer << ":#{name} => "
-					buffer << pretty(object.instance_variable_get(name), indent:)
-					buffer << ",\n"
+
+				if indent < max_depth
+					object.instance_variables.take(max_instance_variables).each do |name|
+						buffer << ("\t" * indent)
+						buffer << ":#{name} => "
+
+						variable = object.instance_variable_get(name)
+
+						if variable && variable != object
+							if variable == object
+								buffer << "[self]"
+							else
+								buffer << pretty(variable, indent:).to_s
+							end
+						else
+							buffer << variable.inspect
+						end
+
+						buffer << ",\n"
+					end
+
+					if object.instance_variables.count > max_instance_variables
+						buffer << ("\t" * indent)
+						buffer << "...\n"
+					end
+				else
+					buffer << "..."
 				end
+
 				indent -= 1
 				buffer << ("\t" * indent)
 				buffer << ")"
+			elsif indent >= max_depth
+				buffer << "#{object.class.name}(...)"
 			else
 				buffer << "#{object.class.name}()"
 			end

--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -164,7 +164,8 @@ module Difftastic
 						buffer << "...\n"
 					end
 				else
-					buffer << "..."
+					buffer << ("\t" * indent)
+					buffer << "...\n"
 				end
 
 				indent -= 1

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -195,6 +195,10 @@ test "pathname" do
 	assert_equal_ruby Difftastic.pretty(Pathname.new("/")), <<~RUBY.chomp
 		Pathname("/")
 	RUBY
+
+	assert_equal_ruby Difftastic.pretty(Pathname.new("/path/to/somewhere.txt")), <<~RUBY.chomp
+		Pathname("/path/to/somewhere.txt")
+	RUBY
 end
 
 test "max_instance_variables" do

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -186,3 +186,60 @@ test "module and class" do
 		[Difftastic, Integer]
 	RUBY
 end
+test "max_instance_variables" do
+	object = Object.new
+
+	1.upto(30) do |i|
+		object.instance_variable_set(:"@variable_#{i}", i)
+	end
+
+	assert_equal_ruby Difftastic.pretty(object), <<~RUBY.chomp
+    Object(
+      :@variable_1 => 1,
+      :@variable_2 => 2,
+      :@variable_3 => 3,
+      :@variable_4 => 4,
+      :@variable_5 => 5,
+      :@variable_6 => 6,
+      :@variable_7 => 7,
+      :@variable_8 => 8,
+      :@variable_9 => 9,
+      :@variable_10 => 10,
+      ...
+    )
+RUBY
+end
+
+test "max_depth" do
+	max_depth = Class.new do
+		def self.name
+			"MaxDepth"
+		end
+
+		def initialize(value)
+			@value = value
+		end
+	end
+
+	level4 = max_depth.new(["level4"])
+	level3 = max_depth.new(["level3", level4])
+	level2 = max_depth.new(["level2", level3])
+	level1 = max_depth.new(["level1", level2])
+	object = max_depth.new(["object", level1])
+
+	assert_equal_ruby Difftastic.pretty(object, max_width: 300), <<~RUBY.chomp
+    MaxDepth(
+      :@value => [
+        "object",
+        MaxDepth(
+          :@value => [
+            "level1",
+            MaxDepth(
+              ...
+            ),
+          ],
+        ),
+      ],
+    )
+RUBY
+end

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -195,10 +195,6 @@ test "pathname" do
 	assert_equal_ruby Difftastic.pretty(Pathname.new("/")), <<~RUBY.chomp
 		Pathname("/")
 	RUBY
-
-	assert_equal_ruby Difftastic.pretty(Pathname.new("/path/to/somewhere.txt")), <<~RUBY.chomp
-		Pathname("/path/to/somewhere.txt")
-	RUBY
 end
 
 test "max_instance_variables" do
@@ -209,20 +205,20 @@ test "max_instance_variables" do
 	end
 
 	assert_equal_ruby Difftastic.pretty(object), <<~RUBY.chomp
-    Object(
-      :@variable_1 => 1,
-      :@variable_2 => 2,
-      :@variable_3 => 3,
-      :@variable_4 => 4,
-      :@variable_5 => 5,
-      :@variable_6 => 6,
-      :@variable_7 => 7,
-      :@variable_8 => 8,
-      :@variable_9 => 9,
-      :@variable_10 => 10,
-      ...
-    )
-RUBY
+		Object(
+			:@variable_1 => 1,
+			:@variable_2 => 2,
+			:@variable_3 => 3,
+			:@variable_4 => 4,
+			:@variable_5 => 5,
+			:@variable_6 => 6,
+			:@variable_7 => 7,
+			:@variable_8 => 8,
+			:@variable_9 => 9,
+			:@variable_10 => 10,
+			...
+		)
+	RUBY
 end
 
 test "max_depth" do
@@ -243,18 +239,18 @@ test "max_depth" do
 	object = max_depth.new(["object", level1])
 
 	assert_equal_ruby Difftastic.pretty(object, max_width: 300), <<~RUBY.chomp
-    MaxDepth(
-      :@value => [
-        "object",
-        MaxDepth(
-          :@value => [
-            "level1",
-            MaxDepth(
-              ...
-            ),
-          ],
-        ),
-      ],
-    )
-RUBY
+		MaxDepth(
+			:@value => [
+				"object",
+				MaxDepth(
+					:@value => [
+						"level1",
+						MaxDepth(
+							...
+						),
+					],
+				),
+			],
+		)
+	RUBY
 end


### PR DESCRIPTION
I noticed that some complex objects (potentially those that have a reference to themselves in any of their instance variables in the stack) cause an infinite loop which leads to a `SystemStackError`:

```
Error:
AssertionTest#test_assert_predicate_Huge_Object_:empty?:
SystemStackError: 8367 -> 29
    test/models/assertion_test.rb:44:in `block in <class:AssertionTest>'
```

I tried to limit the recursion of the `pretty` method by adding a `max_width` and also a `max_instance_variables` to keep the output manageable.

You should be able to reproduce this with something like:
```ruby
irb(main):001> puts Difftastic.pretty(ActionDispatch::TestResponse.new)

/Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:136:in `each': stack level too deep (SystemStackError)
        from /Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:136:in `pretty'
        from /Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:139:in `block in pretty'
        from /Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:136:in `each'
        from /Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:136:in `pretty'
        from /Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:139:in `block in pretty'
        from /Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:136:in `each'
        from /Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:136:in `pretty'
        from /Users/marcoroth/Development/difftastic-ruby/lib/difftastic.rb:139:in `block in pretty'
         ... 8342 levels...
        from /Users/marcoroth/.local/share/mise/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.25.4/lib/minitest.rb:332:in `map'
        from /Users/marcoroth/.local/share/mise/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.25.4/lib/minitest.rb:332:in `__run'
        from /Users/marcoroth/.local/share/mise/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.25.4/lib/minitest.rb:288:in `run'
        from /Users/marcoroth/.local/share/mise/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/minitest-5.25.4/lib/minitest.rb:86:in `block in autorun'
```