### PR TITLE
Support `Pathname` in `Difftastic.pretty`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -128,6 +128,8 @@ module Difftastic
 			end
 		when Module
 			object.name
+		when Pathname
+			%(Pathname("#{object.to_path}"))
 		when Symbol, String, Integer, Float, Regexp, Range, Rational, Complex, true, false, nil
 			object.inspect
 		else

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -186,3 +186,17 @@ test "module and class" do
 		[Difftastic, Integer]
 	RUBY
 end
+
+test "pathname" do
+	assert_equal_ruby Difftastic.pretty(Pathname.new("")), <<~RUBY.chomp
+		Pathname("")
+	RUBY
+
+	assert_equal_ruby Difftastic.pretty(Pathname.new("/")), <<~RUBY.chomp
+		Pathname("/")
+	RUBY
+
+	assert_equal_ruby Difftastic.pretty(Pathname.new("/path/to/somewhere.txt")), <<~RUBY.chomp
+		Pathname("/path/to/somewhere.txt")
+	RUBY
+end


### PR DESCRIPTION
This pull request adds support for pretty-printing `Pathname` objects in the `Difftastic.pretty()` method. Not sure how far we want to go with customizing the pretty-printing support for classes, but I feel like it makes sense for classes in the stdlib.

**Before**:

![CleanShot 2025-01-28 at 22 24 08@2x](https://github.com/user-attachments/assets/2e244e22-6a80-4379-b8c1-85eb70b03143)


**After**:

![CleanShot 2025-01-28 at 22 22 59@2x](https://github.com/user-attachments/assets/7cab6554-de87-4e85-9807-2c6fc067c845)
