### PR TITLE
Add support for self-referencing objects to `pretty`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -74,7 +74,11 @@ module Difftastic
 		exe_file
 	end
 
-	def self.pretty(object, indent: 0, tab_width: 2, max_width: 60, max_depth: 5, max_instance_variables: 10)
+	def self.pretty(object, indent: 0, tab_width: 2, max_width: 60, max_depth: 5, max_instance_variables: 10, original_object: nil)
+		return "[self]" if object && object == original_object
+
+		original_object ||= object
+
 		case object
 		when Hash
 			return "{}" if object.empty?
@@ -87,10 +91,10 @@ module Difftastic
 				when Symbol
 					buffer << "#{key.name}: "
 				else
-					buffer << pretty(key, indent:)
+					buffer << pretty(key, indent:, original_object:)
 					buffer << " => "
 				end
-				buffer << pretty(value, indent:)
+				buffer << pretty(value, indent:, original_object:)
 				buffer << ",\n"
 			end
 			indent -= 1
@@ -100,7 +104,7 @@ module Difftastic
 			new_lines = false
 			length = 0
 			items = object.map do |item|
-				pretty_item = pretty(item, indent: indent + 1)
+				pretty_item = pretty(item, indent: indent + 1, original_object:)
 				new_lines = true if pretty_item.include?("\n")
 				length += pretty_item.bytesize
 				pretty_item
@@ -115,7 +119,7 @@ module Difftastic
 			new_lines = false
 			length = 0
 			items = object.to_a.sort!.map do |item|
-				pretty_item = pretty(item, indent: indent + 1)
+				pretty_item = pretty(item, indent: indent + 1, original_object:)
 				new_lines = true if pretty_item.include?("\n")
 				length += pretty_item.bytesize
 				pretty_item
@@ -146,11 +150,11 @@ module Difftastic
 
 						variable = object.instance_variable_get(name)
 
-						if variable && variable != object
-							if variable == object
+						if variable
+							if variable == object || variable == original_object
 								buffer << "[self]"
 							else
-								buffer << pretty(variable, indent:).to_s
+								buffer << pretty(variable, indent:, original_object:).to_s
 							end
 						else
 							buffer << variable.inspect

--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -147,19 +147,7 @@ module Difftastic
 					object.instance_variables.take(max_instance_variables).each do |name|
 						buffer << ("\t" * indent)
 						buffer << ":#{name} => "
-
-						variable = object.instance_variable_get(name)
-
-						if variable
-							if variable == object || variable == original_object
-								buffer << "[self]"
-							else
-								buffer << pretty(variable, indent:, original_object:).to_s
-							end
-						else
-							buffer << variable.inspect
-						end
-
+						buffer << pretty(object.instance_variable_get(name), indent:, original_object:)
 						buffer << ",\n"
 					end
 

--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -75,7 +75,7 @@ module Difftastic
 	end
 
 	def self.pretty(object, indent: 0, tab_width: 2, max_width: 60, max_depth: 5, max_instance_variables: 10, original_object: nil)
-		return "[self]" if object && object == original_object
+		return "self" if object && object == original_object
 
 		original_object ||= object
 

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -217,6 +217,7 @@ test "self-referencing" do
 
 	parent = {
 		object:,
+		self_twice: [object, object]
 	}
 
 	object[:parent] = parent
@@ -232,20 +233,21 @@ test "self-referencing" do
 			id: 1,
 			array: [1, 2, 3],
 			parent: {
-				object: [self],
+				object: self,
+				self_twice: [self, self],
 				children: [
-					[self],
+					self,
 					{
 						id: 2,
 						array: [3, 2, 1],
-						previous_sibling: [self],
+						previous_sibling: self,
 					},
 				],
 			},
 			next_sibling: {
 				id: 2,
 				array: [3, 2, 1],
-				previous_sibling: [self],
+				previous_sibling: self,
 			},
 		}
 	RUBY

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -201,6 +201,56 @@ test "pathname" do
 	RUBY
 end
 
+test "self-referencing" do
+	array = [1, 2, 3]
+
+	object = {
+		id: 1,
+		array:,
+	}
+
+	sibling = {
+		id: 2,
+		array: array.reverse,
+		previous_sibling: object,
+	}
+
+	parent = {
+		object:,
+	}
+
+	object[:parent] = parent
+	object[:next_sibling] = sibling
+
+	parent[:children] = [
+		object,
+		sibling,
+	]
+
+	assert_equal_ruby Difftastic.pretty(object), <<~RUBY.chomp
+		{
+			id: 1,
+			array: [1, 2, 3],
+			parent: {
+				object: [self],
+				children: [
+					[self],
+					{
+						id: 2,
+						array: [3, 2, 1],
+						previous_sibling: [self],
+					},
+				],
+			},
+			next_sibling: {
+				id: 2,
+				array: [3, 2, 1],
+				previous_sibling: [self],
+			},
+		}
+	RUBY
+end
+
 test "max_instance_variables" do
 	object = Object.new
 


### PR DESCRIPTION
~~I had this branch sitting locally but wanted to wait for #13 to be merged first.~~

This pull request adds support for object which are referencing themselves. This currently causes an infinite loop when trying to pretty print them.

Here's what the output looks like:

```ruby
{
  id: 1,
  array: [1, 2, 3],
  parent: {
    object: [self],
    children: [
      [self],
      {
        id: 2,
        array: [3, 2, 1],
        previous_sibling: [self],
      },
    ],
  },
  next_sibling: {
    id: 2,
    array: [3, 2, 1],
    previous_sibling: [self],
  },
}
```


Closes #16 
Depends on #13
