### PR TITLE
Remove invalid link from `ExecutableNotFoundException`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -65,9 +65,7 @@ module Difftastic
 				See `bundle lock --help` output for details.
 
 				If you're still seeing this message after taking those steps, try running
-				`bundle config` and ensure `force_ruby_platform` isn't set to `true`. See
-				https://github.com/fractaledmind/difftastic-ruby#check-bundle_force_ruby_platform
-				for more details.
+				`bundle config` and ensure `force_ruby_platform` isn't set to `true`.
 			MESSAGE
 		end
 


### PR DESCRIPTION
This pull request just removes the URL in the `ExecutableNotFoundException` which currently doesn't point anywhere. Maybe we can add it back if we have the right content for it the README.