### PR TITLE
Improve pretty output of `DateTime`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -132,10 +132,8 @@ module Difftastic
 			object.name
 		when Pathname
 			%(Pathname("#{object.to_path}"))
-		when Time
-			%(Time("#{object.to_s}"))
-		when Date
-			%(Date("#{object.to_s}"))
+		when Date, DateTime, Time
+			%(#{object.class.name}("#{object.to_s}"))
 		when Symbol, String, Integer, Float, Regexp, Range, Rational, Complex, true, false, nil
 			object.inspect
 		when Data

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -115,6 +115,10 @@ test "date" do
 	assert_equal_ruby Difftastic.pretty(Date.parse("2015-01-31")), %(Date("2015-01-31"))
 end
 
+test "date time" do
+	assert_equal_ruby Difftastic.pretty(DateTime.parse("2025-01-31 11:17:18 +0100")), %(DateTime("2025-01-31T11:17:18+01:00"))
+end
+
 test "sets are sorted" do
 	object = Set[2, 3, 1]
 


### PR DESCRIPTION
This pull request adds support for pretty-printing `DateTime` objects in the `Difftastic.pretty` method.

Before:

```ruby
irb(main):001> puts Difftastic.pretty(DateTime.now)
DateTime("")
```

After:
```ruby
irb(main):001> puts Difftastic.pretty(DateTime.now)
DateTime("2025-01-31T11:23:22+01:00")
```