### PR TITLE
Improve pretty output of `Time`

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -132,6 +132,8 @@ module Difftastic
 			object.name
 		when Pathname
 			%(Pathname("#{object.to_path}"))
+		when Time
+			%(Time("#{object.to_s}"))
 		when Symbol, String, Integer, Float, Regexp, Range, Rational, Complex, true, false, nil
 			object.inspect
 		else

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -35,6 +35,10 @@ test "empty symbol" do
 	assert_equal_ruby Difftastic.pretty(:""), %(:"")
 end
 
+test "time" do
+	assert_equal_ruby Difftastic.pretty(Time.at(1738319106)), %(Time("2025-01-31 11:25:06 +0100"))
+end
+
 test "sets are sorted" do
 	object = Set[2, 3, 1]
 


### PR DESCRIPTION
This pull request adds support for pretty-printing `Time` objects in the `Difftastic.pretty` method.

Before:

```ruby
irb(main):001> puts Difftastic.pretty(Time.now)
Time("")
```

After:
```ruby
irb(main):001> puts Difftastic.pretty(Time.now)
Time("2025-01-31 11:26:36 +0100")
```