### PR TITLE
Add tests for all classes covered by `Difftastic.pretty`

### DIFF
--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -10,9 +10,7 @@ test "objects" do
 end
 
 test "object with no properties" do
-	assert_equal_ruby Difftastic.pretty(Object.new), <<~RUBY.chomp
-		Object()
-	RUBY
+	assert_equal_ruby Difftastic.pretty(Object.new), %(Object())
 end
 
 test "empty set" do
@@ -33,6 +31,53 @@ end
 
 test "empty symbol" do
 	assert_equal_ruby Difftastic.pretty(:""), %(:"")
+end
+
+test "integer" do
+	assert_equal_ruby Difftastic.pretty(-1), %(-1)
+	assert_equal_ruby Difftastic.pretty(0), %(0)
+	assert_equal_ruby Difftastic.pretty(3), %(3)
+end
+
+test "float" do
+	assert_equal_ruby Difftastic.pretty(3.1415), %(3.1415)
+end
+
+test "regexp" do
+	assert_equal_ruby Difftastic.pretty(/\d{2}/), %(/\\d{2}/)
+end
+
+test "range" do
+	assert_equal_ruby Difftastic.pretty(1..10), %(1..10)
+	assert_equal_ruby Difftastic.pretty(1...10), %(1...10)
+end
+
+test "rational" do
+	assert_equal_ruby Difftastic.pretty(Rational(1)), %((1/1))
+	assert_equal_ruby Difftastic.pretty(Rational(2, 3)), %((2/3))
+	assert_equal_ruby Difftastic.pretty(Rational(4, -6)), %((-2/3))
+	assert_equal_ruby Difftastic.pretty(3.to_r), %((3/1))
+	assert_equal_ruby Difftastic.pretty(2/3r), %((2/3))
+end
+
+test "complex" do
+	assert_equal_ruby Difftastic.pretty(2+1i), %((2+1i))
+	assert_equal_ruby Difftastic.pretty(Complex(1)), %((1+0i))
+	assert_equal_ruby Difftastic.pretty(Complex(2, 3)), %((2+3i))
+	assert_equal_ruby Difftastic.pretty(Complex.polar(2, 3)), %((-1.9799849932008908+0.2822400161197344i))
+	assert_equal_ruby Difftastic.pretty(3.to_c), %((3+0i))
+end
+
+test "true" do
+	assert_equal_ruby Difftastic.pretty(true), %(true)
+end
+
+test "false" do
+	assert_equal_ruby Difftastic.pretty(false), %(false)
+end
+
+test "nil" do
+	assert_equal_ruby Difftastic.pretty(nil), %(nil)
 end
 
 test "sets are sorted" do


### PR DESCRIPTION
This pull request adds new test cases for `integer`, `float`, `regexp`, `range`, `rational`, `complex`, `true`, `false`, and `nil` to ensure the `Difftastic.pretty` method handles these types correctly.