### PR TITLE
Improve pretty output of `Data` objects

### DIFF
--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -140,18 +140,18 @@ module Difftastic
 			total_count = object.members.length
 			items = members.map { |key| [key, object.__send__(key)] }
 
-			pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:)
+			pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:, separator: ": ")
 		else
 			buffer = +""
 			instance_variables = object.instance_variables.take(max_instance_variables)
 			total_count = object.instance_variables.length
 			items = instance_variables.map { |name| [name, object.instance_variable_get(name)] }
 
-			pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:)
+			pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:, separator: " = ")
 		end
 	end
 
-	def self.pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:)
+	def self.pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:, separator:)
 		if total_count > 0 && indent < max_depth
 			buffer << "#{object.class.name}(\n"
 			indent += 1
@@ -159,7 +159,7 @@ module Difftastic
 			if indent < max_depth
 				items.take(max_instance_variables).each do |key, value|
 					buffer << ("\t" * indent)
-					buffer << "#{key} = "
+					buffer << "#{key}#{separator}"
 
 					buffer << pretty(value, indent:, original_object:)
 					buffer << ",\n"

--- a/lib/difftastic.rb
+++ b/lib/difftastic.rb
@@ -134,40 +134,53 @@ module Difftastic
 			%(Pathname("#{object.to_path}"))
 		when Symbol, String, Integer, Float, Regexp, Range, Rational, Complex, true, false, nil
 			object.inspect
+		when Data
+			buffer = +""
+			members = object.members.take(max_instance_variables) # TODO: either rename max_instance_variables to max_properties or define a max_members specifcally for data objects
+			total_count = object.members.length
+			items = members.map { |key| [key, object.__send__(key)] }
+
+			pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:)
 		else
 			buffer = +""
-			instance_variables = object.instance_variables
-			if instance_variables.length > 0 && indent < max_depth
-				buffer << "#{object.class.name}(\n"
-				indent += 1
+			instance_variables = object.instance_variables.take(max_instance_variables)
+			total_count = object.instance_variables.length
+			items = instance_variables.map { |name| [name, object.instance_variable_get(name)] }
 
-				if indent < max_depth
-					object.instance_variables.take(max_instance_variables).each do |name|
-						buffer << ("\t" * indent)
-						buffer << name.name
-						buffer << " = "
+			pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:)
+		end
+	end
 
-						buffer << pretty(object.instance_variable_get(name), indent:, original_object:)
-						buffer << ",\n"
-					end
+	def self.pretty_print_object(object:, original_object:, buffer:, items:, total_count:, indent:, max_depth:, max_instance_variables:)
+		if total_count > 0 && indent < max_depth
+			buffer << "#{object.class.name}(\n"
+			indent += 1
 
-					if object.instance_variables.count > max_instance_variables
-						buffer << ("\t" * indent)
-						buffer << "...\n"
-					end
-				else
+			if indent < max_depth
+				items.take(max_instance_variables).each do |key, value|
+					buffer << ("\t" * indent)
+					buffer << "#{key} = "
+
+					buffer << pretty(value, indent:, original_object:)
+					buffer << ",\n"
+				end
+
+				if total_count > max_instance_variables
 					buffer << ("\t" * indent)
 					buffer << "...\n"
 				end
-
-				indent -= 1
-				buffer << ("\t" * indent)
-				buffer << ")"
-			elsif indent >= max_depth
-				buffer << "#{object.class.name}(...)"
 			else
-				buffer << "#{object.class.name}()"
+				buffer << ("\t" * indent)
+				buffer << "...\n"
 			end
+
+			indent -= 1
+			buffer << ("\t" * indent)
+			buffer << ")"
+		elsif indent >= max_depth
+			buffer << "#{object.class.name}(...)"
+		else
+			buffer << "#{object.class.name}()"
 		end
 	end
 end

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -15,6 +15,31 @@ test "object with no properties" do
 	RUBY
 end
 
+test "data objects" do
+	measure = Data.define(:amount, :unit) do
+		def self.name
+			"Measure"
+		end
+	end
+
+	assert_equal_ruby Difftastic.pretty(measure.new(100, "km")), <<~RUBY.chomp
+		Measure(
+			amount = 100,
+			unit = "km",
+		)
+	RUBY
+end
+
+test "data objects with no properties" do
+	empty = Data.define do
+		def self.name
+			"Empty"
+		end
+	end
+
+	assert_equal_ruby Difftastic.pretty(empty.new), %(Empty())
+end
+
 test "empty set" do
 	assert_equal_ruby Difftastic.pretty(Set.new), "Set[]"
 end
@@ -217,7 +242,7 @@ test "self-referencing" do
 
 	parent = {
 		object:,
-		self_twice: [object, object]
+		self_twice: [object, object],
 	}
 
 	object[:parent] = parent

--- a/test/pretty.test.rb
+++ b/test/pretty.test.rb
@@ -24,8 +24,8 @@ test "data objects" do
 
 	assert_equal_ruby Difftastic.pretty(measure.new(100, "km")), <<~RUBY.chomp
 		Measure(
-			amount = 100,
-			unit = "km",
+			amount: 100,
+			unit: "km",
 		)
 	RUBY
 end


### PR DESCRIPTION
This pull request adds support for pretty-printing `Data` objects in the `Difftastic.pretty` method. It additionally extracts the previous `Object` logic into a new `pretty_print_object` method which is now used for both `Object` and `Data`.

**Before**:

```ruby
irb(main):001> Measure = Data.define(:amount, :unit)

irb(main):002> distance = Measure.new(100, 'km')

irb(main):003> puts Difftastic.pretty(distance)
Measure()
```

**After**:

```ruby
irb(main):001> Measure = Data.define(:amount, :unit)

irb(main):002> distance = Measure.new(100, 'km')

irb(main):003> puts Difftastic.pretty(distance)
Measure(
  amount: 100,
  unit: "km",
)
```

Resolves #24 