### PR TITLE
Improve `Differ#diff_files` to take any kind of file

### DIFF
--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -289,8 +289,8 @@ class Difftastic::Differ
 
 	def diff_files(old_file, new_file)
 		options = [
-			(old_file.path),
-			(new_file.path),
+			(file_to_path(old_file)),
+			(file_to_path(new_file)),
 			("--color=#{@color}" if @color),
 			("--context=#{@context}" if @context),
 			("--background=#{@background}" if @background),
@@ -303,7 +303,7 @@ class Difftastic::Differ
 		result = Difftastic.execute(options.join(" ")).lstrip.sub(/\n{2}\z/, "")
 
 		unless @show_paths
-			new_line_index = result.index("\n") + 1
+			new_line_index = (result.index("\n") || 0) + 1
 			result = result.byteslice(new_line_index, result.bytesize - new_line_index)
 		end
 
@@ -361,5 +361,14 @@ class Difftastic::Differ
 		minimum_offset = 29
 
 		[minimum_offset, offset].max
+	end
+
+	def file_to_path(file)
+		return file if file.is_a?(String)
+		return file.path if file.is_a?(File)
+		return file.path if file.is_a?(Tempfile)
+		return file.to_s if file.is_a?(Pathname) # just to be explicit
+
+		file.to_s
 	end
 end

--- a/test/diff_files.test.rb
+++ b/test/diff_files.test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+differ = output = Difftastic::Differ.new(color: :never, tab_width: 2)
+
+test "nil" do
+	output = differ.diff_files(nil, nil)
+
+	assert_equal output, nil
+end
+
+test "String" do
+	a_path = "a_path_#{rand(10000)}.txt"
+	b_path = "b_path_#{rand(10000)}.txt"
+
+	File.write(a_path, "A")
+	File.write(b_path, "B")
+
+	output = differ.diff_files(a_path, b_path)
+
+	begin
+		assert_equal output, "1 A                           1 B"
+	ensure
+		FileUtils.rm(a_path)
+		FileUtils.rm(b_path)
+	end
+end
+
+test "Pathname" do
+	a_path = "a_path_#{rand(10000)}.txt"
+	b_path = "b_path_#{rand(10000)}.txt"
+
+	a = Pathname.new(a_path)
+	b = Pathname.new(b_path)
+
+	a.write("A")
+	b.write("B")
+
+	output = differ.diff_files(a, b)
+
+	begin
+		assert_equal output, "1 A                           1 B"
+	ensure
+		FileUtils.rm(a_path)
+		FileUtils.rm(b_path)
+	end
+end
+
+test "File" do
+	a_path = "a_path_#{rand(10000)}.txt"
+	b_path = "b_path_#{rand(10000)}.txt"
+
+	a = File.new(a_path, "w")
+	b = File.new(b_path, "w")
+
+	a.write("A")
+	b.write("B")
+
+	a.rewind
+	b.rewind
+
+	output = differ.diff_files(a, b)
+
+	begin
+		assert_equal output, "1 A                           1 B"
+	ensure
+		a.close
+		b.close
+
+		FileUtils.rm(a_path)
+		FileUtils.rm(b_path)
+	end
+end
+
+test "Tempfile" do
+	a = Tempfile.new("a.txt")
+	b = Tempfile.new("b.txt")
+
+	a.write("A")
+	a.rewind
+
+	b.write("B")
+	b.rewind
+
+	output = differ.diff_files(a, b)
+
+	begin
+		assert_equal output, "1 A                           1 B"
+	ensure
+		a.unlink
+		b.unlink
+	end
+end


### PR DESCRIPTION
This pull request improves `Differ#diff_files` to take any kind of file, namely `String`, `Pathname`, `File`, or `Tempfile`.

Previously the method only worked if the arguments passed to `Differ#diff_files` responded to `path`.

Let me know if you can think of any other file we are not covering right now.