### PR TITLE
Include aarch64-linux in platform list

### DIFF
--- a/lib/difftastic/upstream.rb
+++ b/lib/difftastic/upstream.rb
@@ -7,6 +7,7 @@ module Difftastic
 		NATIVE_PLATFORMS = {
 			"arm64-darwin" => "difft-aarch64-apple-darwin.tar.gz",
 			"arm64-linux" => "difft-aarch64-unknown-linux-gnu.tar.gz",
+			"aarch64-linux" => "difft-aarch64-unknown-linux-gnu.tar.gz",
 			"x86_64-darwin" => "difft-x86_64-apple-darwin.tar.gz",
 			"x86_64-linux" => "difft-x86_64-unknown-linux-gnu.tar.gz",
 		}.freeze


### PR DESCRIPTION
In docker, you can have Gem::Platform.local return:

```
(dev)> Gem::Platform.local
=> #<Gem::Platform:0x0000ffff8ad45280 @cpu="aarch64", @os="linux", @version=nil>
```

This PR will let difftastic work in this environment.