### PR TITLE
Add adaptive max_depth and max_items handling in diff_objects

### DIFF
--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -8,6 +8,7 @@ class Difftastic::Differ
 	DEFAULT_MAX_ITEMS_CAP = 40
 	MAX_DEPTH_INCREMENT = 5
 	MAX_ITEMS_INCREMENT = 10
+	DIFF_UNAVAILABLE_MESSAGE = "[Diff unavailable: exceeded depth/size display limits]"
 
 	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, width: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil, display: "side-by-side-show-both", max_depth: nil, max_items: nil, max_depth_cap: nil, max_items_cap: nil)
 		@show_paths = false
@@ -49,7 +50,7 @@ class Difftastic::Differ
 
 			# If we've hit both caps, stop trying
 			if max_depth >= max_depth_cap && max_items >= max_items_cap
-				return diff_strings(old_str, new_str, file_extension: "rb")
+				return DIFF_UNAVAILABLE_MESSAGE
 			end
 
 			# Increase limits and retry, while never increasing to more than max_depth_cap/max_items_cap

--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -10,7 +10,7 @@ class Difftastic::Differ
 	MAX_ITEMS_INCREMENT = 10
 	DIFF_UNAVAILABLE_MESSAGE = "[Diff unavailable: exceeded depth/size display limits]"
 
-	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, width: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil, display: "side-by-side-show-both", max_depth: nil, max_items: nil, max_depth_cap: nil, max_items_cap: nil)
+	def initialize(background: nil, color: nil, syntax_highlight: nil, context: nil, width: nil, tab_width: nil, parse_error_limit: nil, underline_highlights: true, left_label: nil, right_label: nil, display: "side-by-side-show-both", max_depth: nil, max_items: nil, max_depth_cap: nil, max_items_cap: nil, max_depth_increment: nil, max_items_increment: nil)
 		@show_paths = false
 		@background = background => :dark | :light | nil
 		@color = color => :always | :never | :auto | nil
@@ -27,6 +27,8 @@ class Difftastic::Differ
 		@max_items = max_items => Integer | nil
 		@max_depth_cap = max_depth_cap => Integer | nil
 		@max_items_cap = max_items_cap => Integer | nil
+		@max_depth_increment = max_depth_increment => Integer | nil
+		@max_items_increment = max_items_increment => Integer | nil
 	end
 
 	def diff_objects(old, new)
@@ -35,13 +37,15 @@ class Difftastic::Differ
 		max_items = @max_items || DEFAULT_MAX_ITEMS
 		max_depth_cap = @max_depth_cap || DEFAULT_MAX_DEPTH_CAP
 		max_items_cap = @max_items_cap || DEFAULT_MAX_ITEMS_CAP
+		max_depth_increment = @max_depth_increment || MAX_DEPTH_INCREMENT
+		max_items_increment = @max_items_increment || MAX_ITEMS_INCREMENT
 
 		loop do
 			old_str = Difftastic.pretty(old, tab_width:, max_depth:, max_items:)
 			new_str = Difftastic.pretty(new, tab_width:, max_depth:, max_items:)
 
-			# If prettified strings don't differ, the strings probably where truncated to max_depth and/or max_items
-			# PrettyPlease then correctly did not return un-matching strings
+			# If prettified strings don't differ, the strings probably were truncated to max_depth and/or max_items
+			# PrettyPlease then correctly did not return non-matching strings
 			# In that case we increase max_depth & max_items in the loop
 			# until DEFAULT_MAX_ITEMS_CAP or DEFAULT_MAX_DEPTH_CAP is exceeded
 			if old_str != new_str
@@ -54,9 +58,9 @@ class Difftastic::Differ
 			end
 
 			# Increase limits and retry, while never increasing to more than max_depth_cap/max_items_cap
-			# Both values are matched to perform 3 retries, but neither value would increase to more than its max anyways
-			max_depth = [max_depth + MAX_DEPTH_INCREMENT, max_depth_cap].min
-			max_items = [max_items + MAX_ITEMS_INCREMENT, max_items_cap].min
+			# Both values are matched to perform 3 retries, but neither value would increase beyond its cap anyway
+			max_depth = [max_depth + max_depth_increment, max_depth_cap].min
+			max_items = [max_items + max_items_increment, max_items_cap].min
 		end
 	end
 

--- a/lib/difftastic/differ.rb
+++ b/lib/difftastic/differ.rb
@@ -44,10 +44,9 @@ class Difftastic::Differ
 			old_str = Difftastic.pretty(old, tab_width:, max_depth:, max_items:)
 			new_str = Difftastic.pretty(new, tab_width:, max_depth:, max_items:)
 
-			# If prettified strings don't differ, the strings probably were truncated to max_depth and/or max_items
-			# PrettyPlease then correctly did not return non-matching strings
-			# In that case we increase max_depth & max_items in the loop
-			# until DEFAULT_MAX_ITEMS_CAP or DEFAULT_MAX_DEPTH_CAP is exceeded
+			# If prettified strings don't differ, the strings probably were truncated to max_depth and/or max_items.
+			# PrettyPlease then correctly did not return non-matching strings.
+			# In that case we increase max_depth & max_items in the loop up to DEFAULT_MAX_ITEMS_CAP or DEFAULT_MAX_DEPTH_CAP.
 			if old_str != new_str
 				return diff_strings(old_str, new_str, file_extension: "rb")
 			end
@@ -57,8 +56,8 @@ class Difftastic::Differ
 				return DIFF_UNAVAILABLE_MESSAGE
 			end
 
-			# Increase limits and retry, while never increasing to more than max_depth_cap/max_items_cap
-			# Both values are matched to perform 3 retries, but neither value would increase beyond its cap anyway
+			# Increase limits and retry, while never increasing to more than max_depth_cap/max_items_cap.
+			# Both values are matched to perform 3 retries, but neither value would increase beyond its cap anyway.
 			max_depth = [max_depth + max_depth_increment, max_depth_cap].min
 			max_items = [max_items + max_items_increment, max_items_cap].min
 		end

--- a/test/diff_objects_adaptive_test.rb
+++ b/test/diff_objects_adaptive_test.rb
@@ -7,12 +7,15 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 	# The adaptive logic works the same regardless of the actual values.
 	TEST_MAX_DEPTH = 3
 	TEST_MAX_ITEMS = 5
+	TEST_INCREMENT = 1
 
 	def differ(**options)
 		Difftastic::Differ.new(
 			color: :never,
 			max_depth: TEST_MAX_DEPTH,
 			max_items: TEST_MAX_ITEMS,
+			max_depth_increment: TEST_INCREMENT,
+			max_items_increment: TEST_INCREMENT,
 			**options # overrides defaults when provided
 		)
 	end

--- a/test/diff_objects_adaptive_test.rb
+++ b/test/diff_objects_adaptive_test.rb
@@ -8,6 +8,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 	TEST_MAX_DEPTH = 3
 	TEST_MAX_ITEMS = 5
 	TEST_INCREMENT = 1
+	DIFF_UNAVAILABLE_MESSAGE = Difftastic::Differ::DIFF_UNAVAILABLE_MESSAGE
 
 	def differ(**options)
 		Difftastic::Differ.new(
@@ -41,7 +42,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ.diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -53,7 +54,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ.diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -65,7 +66,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ.diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -78,7 +79,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ.diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -90,7 +91,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ.diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -102,7 +103,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ.diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -116,7 +117,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ(max_depth: 1).diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -128,7 +129,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ(max_items: 1).diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -142,7 +143,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ(max_depth_cap: depth + 1).diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -154,7 +155,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ(max_items_cap: position + 1).diff_objects(old, new)
 
-			refute_includes output, "No changes"
+			refute_includes output, DIFF_UNAVAILABLE_MESSAGE
 			assert_includes output, "old"
 			assert_includes output, "new"
 		end
@@ -169,7 +170,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ(max_depth_cap: cap).diff_objects(old, new)
 
-			assert_includes output, Difftastic::Differ::DIFF_UNAVAILABLE_MESSAGE
+			assert_includes output, DIFF_UNAVAILABLE_MESSAGE
 		end
 
 		it "returns unavailable message when position exceeds max_items_cap" do
@@ -180,7 +181,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ(max_items_cap: cap).diff_objects(old, new)
 
-			assert_includes output, Difftastic::Differ::DIFF_UNAVAILABLE_MESSAGE
+			assert_includes output, DIFF_UNAVAILABLE_MESSAGE
 		end
 	end
 end

--- a/test/diff_objects_adaptive_test.rb
+++ b/test/diff_objects_adaptive_test.rb
@@ -230,6 +230,8 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 			output = differ.diff_objects(old, new)
 
 			assert_includes output, DIFF_UNAVAILABLE_MESSAGE
+			refute_includes output, "old"
+			refute_includes output, "new"
 		end
 
 		it "returns unavailable message when position exceeds max_items_cap" do
@@ -240,6 +242,8 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 			output = differ.diff_objects(old, new)
 
 			assert_includes output, DIFF_UNAVAILABLE_MESSAGE
+			refute_includes output, "old"
+			refute_includes output, "new"
 		end
 	end
 end

--- a/test/diff_objects_adaptive_test.rb
+++ b/test/diff_objects_adaptive_test.rb
@@ -158,7 +158,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 	end
 
 	describe "loop termination at caps" do
-		it "terminates with 'No changes' when depth exceeds max_depth_cap" do
+		it "returns unavailable message when depth exceeds max_depth_cap" do
 			cap = TEST_MAX_DEPTH + 2
 			depth = cap + 1
 			old = nested_hash(depth, "old")
@@ -166,10 +166,10 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ(max_depth_cap: cap).diff_objects(old, new)
 
-			assert_includes output, "No changes", "Loop should terminate at cap and return 'No changes'"
+			assert_includes output, Difftastic::Differ::DIFF_UNAVAILABLE_MESSAGE
 		end
 
-		it "terminates with 'No changes' when position exceeds max_items_cap" do
+		it "returns unavailable message when position exceeds max_items_cap" do
 			cap = TEST_MAX_ITEMS + 5
 			position = cap + 1
 			old = array_with_diff_at(position, "old")
@@ -177,7 +177,7 @@ class DiffObjectsAdaptiveTest < Minitest::Spec
 
 			output = differ(max_items_cap: cap).diff_objects(old, new)
 
-			assert_includes output, "No changes", "Loop should terminate at cap and return 'No changes'"
+			assert_includes output, Difftastic::Differ::DIFF_UNAVAILABLE_MESSAGE
 		end
 	end
 end

--- a/test/diff_objects_adaptive_test.rb
+++ b/test/diff_objects_adaptive_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class DiffObjectsAdaptiveTest < Minitest::Spec
+	DEFAULT_MAX_DEPTH = Difftastic::Differ::DEFAULT_MAX_DEPTH
+	DEFAULT_MAX_ITEMS = Difftastic::Differ::DEFAULT_MAX_ITEMS
+
+	def nested_hash(depth, leaf_value)
+		(1..depth).reverse_each.reduce(leaf_value) { |inner, i| { "l#{i}": inner } }
+	end
+
+	def array_with_diff_at(position, value)
+		(1...position).to_a + [value]
+	end
+
+	describe "adaptive max_depth" do
+		it "shows diff at exactly DEFAULT_MAX_DEPTH" do
+			old = nested_hash(DEFAULT_MAX_DEPTH, "old")
+			new = nested_hash(DEFAULT_MAX_DEPTH, "new")
+
+			output = Difftastic::Differ.new(color: :never).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+			assert_includes output, "old"
+			assert_includes output, "new"
+		end
+
+		it "shows diff at DEFAULT_MAX_DEPTH + 1 (requires adaptation)" do
+			depth = DEFAULT_MAX_DEPTH + 1
+			old = nested_hash(depth, "old")
+			new = nested_hash(depth, "new")
+
+			output = Difftastic::Differ.new(color: :never).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+			assert_includes output, "old"
+			assert_includes output, "new"
+		end
+
+		it "shows diff at 2 * DEFAULT_MAX_DEPTH (requires multiple adaptations)" do
+			depth = 2 * DEFAULT_MAX_DEPTH
+			old = nested_hash(depth, "old")
+			new = nested_hash(depth, "new")
+
+			output = Difftastic::Differ.new(color: :never).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+			assert_includes output, "old"
+			assert_includes output, "new"
+		end
+	end
+
+	describe "adaptive max_items" do
+		it "shows diff at exactly DEFAULT_MAX_ITEMS" do
+			old = array_with_diff_at(DEFAULT_MAX_ITEMS, "old")
+			new = array_with_diff_at(DEFAULT_MAX_ITEMS, "new")
+
+			output = Difftastic::Differ.new(color: :never).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+			assert_includes output, "old"
+			assert_includes output, "new"
+		end
+
+		it "shows diff at DEFAULT_MAX_ITEMS + 1 (requires adaptation)" do
+			position = DEFAULT_MAX_ITEMS + 1
+			old = array_with_diff_at(position, "old")
+			new = array_with_diff_at(position, "new")
+
+			output = Difftastic::Differ.new(color: :never).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+			assert_includes output, "old"
+			assert_includes output, "new"
+		end
+
+		it "shows diff at 2 * DEFAULT_MAX_ITEMS (requires multiple adaptations)" do
+			position = 2 * DEFAULT_MAX_ITEMS
+			old = array_with_diff_at(position, "old")
+			new = array_with_diff_at(position, "new")
+
+			output = Difftastic::Differ.new(color: :never).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+			assert_includes output, "old"
+			assert_includes output, "new"
+		end
+	end
+
+	describe "configurable starting values" do
+		it "respects custom max_depth" do
+			depth = DEFAULT_MAX_DEPTH - 2
+			old = nested_hash(depth, "old")
+			new = nested_hash(depth, "new")
+
+			output = Difftastic::Differ.new(color: :never, max_depth: 1).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+		end
+
+		it "respects custom max_items" do
+			position = DEFAULT_MAX_ITEMS - 5
+			old = array_with_diff_at(position, "old")
+			new = array_with_diff_at(position, "new")
+
+			output = Difftastic::Differ.new(color: :never, max_items: 2).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+		end
+	end
+
+	describe "configurable caps" do
+		it "respects custom max_depth_cap" do
+			depth = DEFAULT_MAX_DEPTH + 3
+			old = nested_hash(depth, "old")
+			new = nested_hash(depth, "new")
+
+			output = Difftastic::Differ.new(color: :never, max_depth_cap: depth + 1).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+		end
+
+		it "respects custom max_items_cap" do
+			position = DEFAULT_MAX_ITEMS + 5
+			old = array_with_diff_at(position, "old")
+			new = array_with_diff_at(position, "new")
+
+			output = Difftastic::Differ.new(color: :never, max_items_cap: position + 1).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+		end
+	end
+
+	describe "real-world structures" do
+		it "handles typical API request body" do
+			old = {
+				type: "Request",
+				positions: [{
+					address: {
+						sender: { postalCode: "41564", city: "Kaarst" }
+					}
+				}]
+			}
+			new = {
+				type: "Request",
+				positions: [{
+					address: {
+						sender: { postalCode: "99999", city: "Berlin" }
+					}
+				}]
+			}
+
+			output = Difftastic::Differ.new(color: :never).diff_objects(old, new)
+
+			refute_includes output, "No changes"
+			assert_includes output, "41564"
+			assert_includes output, "99999"
+		end
+	end
+end


### PR DESCRIPTION
Fixes #35.

When comparing deeply nested structures or large arrays, `diff_objects` could return misleading `"No changes.` output because `PrettyPlease` truncates content beyond the passed `max_depth` & `max_items` limits. If both objects are truncated identically, no diff is shown even though the actual objects differ.

See also [the issue in minitest-difftastic](https://github.com/marcoroth/minitest-difftastic/issues/20) for details. 

I concluded - based on our exchange in the `minitest-difftastic` issue, that this is best fixed here and `minitest-difftastic` actually doesn't need any adjustments. 

This PR makes `max_depth` and `max_items` handling adaptive in `diff_objects`, increasing these, up until exceeding newly defined cap values, until either:
- A diff is found (strings differ after prettification) with higher max values
- Both caps are reached → returns "[Diff unavailable: exceeded depth/size display limits]"

Also more of these configurations are exposed in `Difftastic::Differ.initialize` for libraries and gems building upon this to customize this behaviour. 